### PR TITLE
Fixed table header when start_date is :monday

### DIFF
--- a/lib/simple_calendar/view_helpers.rb
+++ b/lib/simple_calendar/view_helpers.rb
@@ -59,7 +59,9 @@ module SimpleCalendar
       today = Date.today
       content_tag(:table, :class => "table table-bordered table-striped calendar") do
         tags << month_header(selected_month, options)
-        tags << content_tag(:thead, content_tag(:tr, I18n.t("date.abbr_day_names").collect { |name| content_tag :th, name, :class => (selected_month.month == Date.today.month && Date.today.strftime("%a") == name ? "current-day" : nil)}.join.html_safe))
+        day_names = I18n.t("date.abbr_day_names")
+        day_names.rotate(1) if options[:start_date] == :monday
+        tags << content_tag(:thead, content_tag(:tr, day_names.collect { |name| content_tag :th, name, :class => (selected_month.month == Date.today.month && Date.today.strftime("%a") == name ? "current-day" : nil)}.join.html_safe))
         tags << content_tag(:tbody, :'data-month'=>selected_month.month, :'data-year'=>selected_month.year) do
 
           month.collect do |week|


### PR DESCRIPTION
When start_date is set to :monday header still remains starting at sunday.
