### PR TITLE
Make the events datetime method configurable

### DIFF
--- a/lib/simple_calendar/view_helpers.rb
+++ b/lib/simple_calendar/view_helpers.rb
@@ -18,13 +18,14 @@ module SimpleCalendar
     private
     def default_options
       {
-          :year       => (params[:year] || Time.zone.now.year).to_i,
-          :month      => (params[:month] || Time.zone.now.month).to_i,
-          :prev_text  => raw("&laquo;"),
-          :next_text  => raw("&raquo;"),
-          :start_day  => :sunday,
-          :class      => "table table-bordered table-striped calendar",
-          :params     => {}
+          :year           => (params[:year] || Time.zone.now.year).to_i,
+          :month          => (params[:month] || Time.zone.now.month).to_i,
+          :prev_text      => raw("&laquo;"),
+          :next_text      => raw("&raquo;"),
+          :start_day      => :sunday,
+          :class          => "table table-bordered table-striped calendar",
+          :params         => {},
+          :time_selector  => "start_time"
       }
     end
     # Returns array of dates between start date and end date for selected month
@@ -57,7 +58,7 @@ module SimpleCalendar
                 td_class << "future" if today < date
                 td_class << "wday-#{date.wday.to_s}" # <- to enable different styles for weekend, etc
 
-                cur_events = day_events(date, events)
+                cur_events = day_events(date, events, options[:time_selector])
 
                 td_class << (cur_events.any? ? "events" : "no-events")
 
@@ -87,8 +88,8 @@ module SimpleCalendar
     end
 
     # Returns an array of events for a given day
-    def day_events(date, events)
-      events.select { |e| e.start_time.to_date == date }.sort_by { |e| e.start_time }
+    def day_events(date, events, time_selector)
+      events.select { |e| e.send(time_selector).to_date == date }.sort_by { |e| e.send(time_selector) }
     end
 
     # Generates the header that includes the month and next and previous months

--- a/spec/simple_calendar_spec.rb
+++ b/spec/simple_calendar_spec.rb
@@ -70,7 +70,7 @@ describe "SimpleCalendar" do
       matching_event = stub(:start_time => Date.new(2013, 1, 14))
       other_event    = stub(:start_time => Date.new(2013,1,15))
       events = [matching_event, other_event]
-      subject.send(:day_events, date, events).should == [matching_event]
+      subject.send(:day_events, date, events, "start_time").should == [matching_event]
     end
   end
 


### PR DESCRIPTION
The method to retrieve an events date, was hardcoded to be "start_time".
If your event model did not have such a method, the advise was to simply
delegate "start_time" to whatever method returns a datetime obejct
representing the start time of your event model.

Instead of adjusting your model to be able to handle simple_calendar, we
should pass in the name of the method that should be called to retrieve
the start time through a configuration option.
