### PR TITLE
Show events spanning more than one day

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ rails g scaffold Meeting name starts_at:datetime
 Here's an example model:
 
 ```bash
-rails g scaffold Event name starts_at:datetime
+rails g scaffold Event name starts_at:datetime ends_at:datetime
 ```
 
 We use the `has_calendar` method to tell simple_calendar how to filter
 and sort the meetings on the different calendar days. This should be the
-start date/time of your meeting. By default it uses `starts_at` as the
-attribute name.
+start and the end date/time of your meeting. By default it uses `starts_at` and 
+and `ends_at` as the attribute names.
 
 ```ruby
 class Meeting < ActiveRecord::Base
@@ -99,7 +99,10 @@ class Meeting < ActiveRecord::Base
   has_calendar
 
   # Or set a custom attribute for simple_calendar to sort by
-  # has_calendar :attribute => :your_starting_time_column_name
+  # has_calendar :attribute => [:your_starting_time_column_name, :your_ending_time_column_name]
+  # The old syntax 
+  # has_calendar :attribute => :your_starting_time_column_name 
+  # is supported extending the ending_time_column_name with the default `ends_at`
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Here's an example model:
 rails g scaffold Meeting name starts_at:datetime
 ```
 
+Here's an example model:
+
+```bash
+rails g scaffold Event name starts_at:datetime
+```
+
 We use the `has_calendar` method to tell simple_calendar how to filter
 and sort the meetings on the different calendar days. This should be the
 start date/time of your meeting. By default it uses `starts_at` as the

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -1,3 +1,5 @@
+require 'rails'
+
 module SimpleCalendar
   class Calendar
     delegate :capture, :concat, :content_tag, :link_to, :params, :raw, :safe_join, to: :view_context

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -71,12 +71,17 @@ module SimpleCalendar
     end
 
     def events_for_date(current_date)
-      if events.any? && events.first.respond_to?(:simple_calendar_start_time)
+      if events.any? && events.first.respond_to?(:simple_calendar_range_time)
+        events.select do |e|
+          e.send(:simple_calendar_range_time).cover? current_date
+        end.sort_by { |e| e.send(:simple_calendar_range_time).begin}
+      else if events.any? && events.first.respond_to?(:simple_calendar_start_time)
         events.select do |e|
           current_date == e.send(:simple_calendar_start_time).in_time_zone(@timezone).to_date
         end.sort_by(&:simple_calendar_start_time)
-      else
-        events
+        else
+          events
+        end
       end
     end
 

--- a/lib/simple_calendar/model_additions.rb
+++ b/lib/simple_calendar/model_additions.rb
@@ -1,14 +1,32 @@
 module SimpleCalendar
   module ModelAdditions
     def has_calendar(options={})
-      config = { :attribute => :starts_at }
-
+      config = { :attribute => [:starts_at, :ends_at] }
       # Override default config
       config.update(options) if options.is_a?(Hash)
 
+      # let's do some sanitizing
+      # is an array? 
+      if config[:attribute].is_a?(Array)
+        # unwanted nil removal
+        config[:attribute].compact!
+        # add default parameters if missing
+        # first, fill empty array case
+        config[:attribute] << :starts_at if config[:attribute].count < 1
+        # next, fill second parameter if missing
+        config[:attribute] << :ends_at if config[:attribute].count < 2
+        # unneded extra parameter removal
+        config[:attribute] = config[:attribute].take(2) if config[:attribute].count > 2
+      else
+        # supporting old option syntax
+        config[:attribute] = [config[:attribute], :ends_at] 
+      end
       class_eval <<-EOV
         def simple_calendar_start_time
-          #{config[:attribute]}
+          #{config[:attribute].first.to_s}
+        end
+        def simple_calendar_range_date
+          (#{config[:attribute].first.to_s}.to_date..#{config[:attribute].last.to_s}.to_date)
         end
       EOV
     end


### PR DESCRIPTION
I work with events read from a vCal file and I needed to show events spanning more than one day in a different look. So I modified _Event_ object to support  **:simple_calendar_range_date** method and to expose **event_start_date**  and **event_end_date** property.
If **:simple_calendar_range_date** method is found then I check if event spans over a date range (**event_start_date**..**event_end_date**) and then I sort events selected by start date.
(Warning: it may result that period with _same_ start date are **not** ordered by end date!)
if **:simple_calendar_range_date** method is not found, then, as before, **:simple_calendar_start_time** method is checked (single date events), else events is passed as is.
