### PR TITLE
fix support for apps with default time_zone different than UTC

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -73,7 +73,7 @@ module SimpleCalendar
     def events_for_date(current_date)
       if events.any? && events.first.respond_to?(:simple_calendar_start_time)
         events.select do |e|
-          current_date == @timezone.utc_to_local(e.send(:simple_calendar_start_time).beginning_of_day).to_date
+          current_date == e.send(:simple_calendar_start_time).in_time_zone(@timezone).to_date
         end.sort_by(&:simple_calendar_start_time)
       else
         events


### PR DESCRIPTION
Hello, i found an error generating a week_calendar in my app and figured out it was because my app is not using the default time_zone config.

More details to reproduce the error in the commit comments.

Great gem, thanks.
