### PR TITLE
Apply 'has-events' class to tds with events. Closes #73

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -121,7 +121,6 @@ module SimpleCalendar
       ->(start_date, current_calendar_date) {
         today = Time.zone.now.to_date
         td_class = ["day"]
-
         td_class << "today"  if today == current_calendar_date
         td_class << "past"   if today > current_calendar_date
         td_class << "future" if today < current_calendar_date
@@ -129,6 +128,7 @@ module SimpleCalendar
         td_class << "next-month"    if start_date.month != current_calendar_date.month && current_calendar_date > start_date
         td_class << "current-month" if start_date.month == current_calendar_date.month
         td_class << "wday-#{current_calendar_date.wday.to_s}"
+        td_class << "has-events" if !events_for_date(current_calendar_date).first.nil?
 
         { class: td_class.join(" ") }
       }
@@ -145,4 +145,3 @@ module SimpleCalendar
     end
   end
 end
-

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -128,7 +128,7 @@ module SimpleCalendar
         td_class << "next-month"    if start_date.month != current_calendar_date.month && current_calendar_date > start_date
         td_class << "current-month" if start_date.month == current_calendar_date.month
         td_class << "wday-#{current_calendar_date.wday.to_s}"
-        td_class << "has-events" if !events_for_date(current_calendar_date).first.nil?
+        td_class << "has-events" if events_for_date(current_calendar_date).any?
 
         { class: td_class.join(" ") }
       }


### PR DESCRIPTION
When styling a calendar, it is typically useful to discriminate between days that have events and those that do not. This PR adds a `has-events` class to td's which contain events. This enables styling such as the below

![screen shot 2015-02-05 at 4 47 05 pm](https://cloud.githubusercontent.com/assets/4101096/6057223/a820b042-ad56-11e4-8cd6-e6d28ec81020.png)
