### PR TITLE
Add SimpleCalendar::Generators::ViewsGenerator spec

### DIFF
--- a/lib/generators/simple_calendar/views_generator.rb
+++ b/lib/generators/simple_calendar/views_generator.rb
@@ -1,3 +1,5 @@
+require 'rails/generators'
+
 module SimpleCalendar
   module Generators
     class ViewsGenerator < Rails::Generators::Base

--- a/spec/views_generators_spec.rb
+++ b/spec/views_generators_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+require "generators/simple_calendar/views_generator"
+
+describe SimpleCalendar::Generators::ViewsGenerator do
+    it 'copies the files to app/views/simple_calendar'
+    it 'verifies the content'
+end


### PR DESCRIPTION
To add this detail, I was getting some ```Rails::Generator``` NameError exception when using RSpec (example below)

```
/home/ubuntu/workspace/lib/generators/simple_calendar/views_generator.rb:3:in `<module:Generators>': uninitialized constant Rails::Generators (NameError)
        from /home/ubuntu/workspace/lib/generators/simple_calendar/views_generator.rb:2:in `<module:SimpleCalendar>'
        from /home/ubuntu/workspace/lib/generators/simple_calendar/views_generator.rb:1:in `<top (required)>'
        from /home/ubuntu/workspace/spec/views_generators_spec.rb:2:in `require'
        from /home/ubuntu/workspace/spec/views_generators_spec.rb:2:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1327:in `load'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1325:in `each'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:102:in `setup'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:88:in `run'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:73:in `run'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:41:in `invoke'
        from /usr/local/rvm/gems/ruby-2.2.1/gems/rspec-core-3.3.1/exe/rspec:4:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-2.2.1/bin/rspec:23:in `load'
        from /usr/local/rvm/gems/ruby-2.2.1/bin/rspec:23:in `<main>'
        from /usr/local/rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `eval'
        from /usr/local/rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `<main>'
```

To solve this problem I had to add ```require rails/generators``` when loading this module to spec. I also added some tests for you to quickstart the journey.