### PR TITLE
users can alias a start time attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ pass it in as the `attribute` option**
   <%= day %>
 <% end %>
 ```
+**If you already have a model with a start time attribute called something other than `start_time` or accesses it through a relationship, you can alias the attribute by defining a `start_time` method in the my_model.rb file and not have to specify it separately as in the above example**
+```ruby
+class MyModel
+    ## Other code related to your model lives here
+    
+    def start_time
+        self.my_related_model.start ##Where 'start' is a attribute of type 'Date' accessible through MyModel's relationship
+    end
+end
+```
 
 In your controller, query for these meetings and store them in an instance
 variable. Normally you'll want to search for the ones that only show up


### PR DESCRIPTION
If you already have a model with a start time attribute called something other than `start_time` or accesses it through a relationship, you can alias the attribute by defining a `start_time` method in the my_model.rb file.

For our use case, we have a `PublishedProgrammeItem` model that has a `start` attribute accessible through its relationship to our `PublishedTimeSlot` model. Instead of trying to hack this gem to accept an attribute from a model's relationship, all I needed to do was define a `start_time` method on the model we  pass to the helper as the `:events` argument.

```ruby
class PublishedProgrammeItem
   #other code
   def start_time
       self.published_time_slot.start
   end
end
```
Then, I just had to call the helper directly without specifying the attribute.

```erb
<%= month_calendar events: @programme_items do |date, items| %>
    <!-- calendar cell contents for each item -->
<% end %>
```

I figured this was a useful addition to the readme for other users trying to integrate this gem with previously established apps. I'd like some feedback on the wording and the example, and of course any other feedback as well. This gem has been really useful, saved a lot of time. I'm happy to give back!