### PR TITLE
Start date can be given as an argument of the view helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+.ruby-version
+.ruby-gemset

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -66,7 +66,11 @@ module SimpleCalendar
       end
 
       def start_date
-        view_context.params.fetch(:start_date, Date.today).to_date
+        if options.has_key?(:start_date)
+          options.fetch(:start_date).to_date
+        else
+          view_context.params.fetch(:start_date, Date.today).to_date
+        end
       end
 
       def date_range

--- a/lib/simple_calendar/version.rb
+++ b/lib/simple_calendar/version.rb
@@ -1,3 +1,3 @@
 module SimpleCalendar
-  VERSION = "2.0.3"
+  VERSION = "2.0.4"
 end

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -45,10 +45,16 @@ describe SimpleCalendar::Calendar do
       expect(calendar.send(:start_date)).to eq(Date.today)
     end
 
-    it "uses the params start_date to override" do
+    it "uses the view context's params start_date to override" do
       view_context = ViewContext.new(Date.yesterday)
       calendar = SimpleCalendar::Calendar.new(view_context)
       expect(calendar.send(:start_date)).to eq(Date.yesterday)
+    end
+
+    it "uses the optional argument's start_date to override view_context's start_date" do
+      view_context = ViewContext.new(Date.yesterday)
+      calendar = SimpleCalendar::Calendar.new(view_context, start_date: Date.tomorrow)
+      expect(calendar.send(:start_date)).to eq(Date.tomorrow)
     end
   end
 


### PR DESCRIPTION
This pull request enables the use of a `start_date`argument on the view helpers to override the view context's start_date params.

This allows the user to display multiple calendars for different time ranges on the same view.

Test coverage is included for the new feature.