### PR TITLE
Refactor the sorted_events method

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -51,7 +51,9 @@ module SimpleCalendar
 
       def sorted_events
         events = options.fetch(:events, []).sort_by(&attribute)
-        events.group_by { |e| e.send(attribute).to_date }
+
+        scheduled = events.reject { |e| e.send(attribute).nil? }
+        scheduled.group_by { |e| e.send(attribute).to_date }
       end
 
       def start_date

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -51,18 +51,7 @@ module SimpleCalendar
 
       def sorted_events
         events = options.fetch(:events, []).sort_by(&attribute)
-        sorted = {}
-
-        events.each do |event|
-          start_time = event.send(attribute)
-          if start_time.present?
-            date = start_time.to_date
-            sorted[date] ||= []
-            sorted[date] << event
-          end
-        end
-
-        sorted
+        events.group_by { |e| e.send(attribute).to_date }
       end
 
       def start_date

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -50,6 +50,13 @@ describe SimpleCalendar::Calendar do
       expect(sorted_events[today]).to eq([event1, event2])
       expect(sorted_events[tomorrow]).to eq([event3])
     end
+
+    it 'handles events without a start time' do
+      event = double(start_time: nil)
+      calendar = SimpleCalendar::Calendar.new(nil, events: [event])
+
+      expect{calendar.send(:sorted_events)}.not_to raise_error
+    end
   end
 
   describe "#start_date" do

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -35,7 +35,21 @@ describe SimpleCalendar::Calendar do
   end
 
   describe "#sorted_events" do
-    it 'converts an array of events to a hash sorted by days'
+    it 'converts an array of events to a hash sorted by days' do
+      today, tomorrow = Date.today, Date.tomorrow
+
+      event1 = double(start_time: today.at_midnight)
+      event2 = double(start_time: today.at_noon)
+      event3 = double(start_time: tomorrow.at_noon)
+
+      events = [event1, event2, event3].shuffle
+      calendar = SimpleCalendar::Calendar.new(nil, events: events)
+
+      sorted_events = calendar.send(:sorted_events)
+
+      expect(sorted_events[today]).to eq([event1, event2])
+      expect(sorted_events[tomorrow]).to eq([event3])
+    end
   end
 
   describe "#start_date" do


### PR DESCRIPTION
`Enumerable#group_by` can be used to simplify the code within the `sorted_events` method.