### PR TITLE
Fix: @view_context.params nil while rendering calendar in an mailer

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -12,7 +12,7 @@ module SimpleCalendar
 
       @params = @view_context.params
       @params = @params.to_unsafe_h if @params.respond_to?(:to_unsafe_h)
-      @params = @params.with_indifferent_access.except(*PARAM_KEY_BLACKLIST)
+      @params = @params.with_indifferent_access.except(*PARAM_KEY_BLACKLIST) unless @params.nil?
     end
 
     def render(&block)

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -10,9 +10,9 @@ module SimpleCalendar
       @view_context = view_context
       @options = opts
 
-      @params = @view_context.params
+      @params = @view_context.respond_to?(:params) ? @view_context.params : Hash.new
       @params = @params.to_unsafe_h if @params.respond_to?(:to_unsafe_h)
-      @params = @params.with_indifferent_access.except(*PARAM_KEY_BLACKLIST) unless @params.nil?
+      @params = @params.with_indifferent_access.except(*PARAM_KEY_BLACKLIST)
     end
 
     def render(&block)


### PR DESCRIPTION
@view_context.params is not defined when using the calendar in a mailer, to fix this we need check if params exists or create an empty hash for further use.