### PR TITLE
Remove unneeded binaries

### DIFF
--- a/simple_calendar.gemspec
+++ b/simple_calendar.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_dependency 'rails', '>= 3.0'


### PR DESCRIPTION
There's no need to install a 'console' or 'setup' binary for this gem, since they're only used for local development