### PR TITLE
Add support for multi-day events

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,18 @@ model called Meeting, but you can add this to any model or Ruby object.
 Here's an example model:
 
 ```bash
+# single day events
 $ rails g scaffold Meeting name start_time:datetime
+
+# multi-day events
+$ rails g scaffold Meeting name start_time:datetime end_time:datetime
 ```
 
-By default it uses `start_time` as the attribute name.
+By default it uses `start_time` as the attribute name.  Optionally the `end_time`
+attribute can be used which enables multi-day event rendering.
 
-**If you'd like to use another attribute other than start_time, just
-pass it in as the `attribute` option**
+**If you'd like to use another attribute other than start_time or end_time, just
+pass it in as the `attribute` or `end_attribute` options respectively**
 
 ```erb
 <%= month_calendar(attribute: :starts_at) do |date| %>
@@ -348,7 +353,6 @@ With modifications as appropriate.
 
 ## TODO
 
-- Multi-day events
 - Rspec tests for Calendar
 - Rspec tests for MonthCalendar
 - Rspec tests for WeekCalendar

--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -75,17 +75,12 @@ module SimpleCalendar
 
       def group_events_by_date(events)
         events_grouped_by_date = Hash.new {|h,k| h[k] = [] }
-        events.each do |event|
-          if event.respond_to?(end_attribute) && !event.respond_to?(end_attribute).nil?
-            event_start_date = event.send(attribute).to_date
-            event_end_date = event.send(end_attribute).to_date
-            max_end_date = event_end_date > end_date ? end_date : event_end_date
 
-            (event_start_date..max_end_date).to_a.each do |enumerated_date|
-              events_grouped_by_date[enumerated_date] << event
-            end
-          else
-            events_grouped_by_date[event.send(attribute).to_date] << event
+        events.each do |event|
+          event_start_date = event.send(attribute).to_date
+          event_end_date = (event.respond_to?(end_attribute) && !event.respond_to?(end_attribute).nil?) ? event.send(end_attribute).to_date : event_start_date
+          (event_start_date..event_end_date).to_a.each do |enumerated_date|
+            events_grouped_by_date[enumerated_date] << event
           end
         end
         events_grouped_by_date

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -62,6 +62,22 @@ describe SimpleCalendar::Calendar do
       expect(sorted_events[tomorrow]).to eq([event3])
     end
 
+    it 'converts an array of multi-day events to a hash sorted by days' do
+      today, tomorrow = Date.today, Date.tomorrow
+
+      event1 = double(start_time: today.at_midnight, end_time: tomorrow.at_midnight)
+      event2 = double(start_time: today.at_noon)
+      event3 = double(start_time: tomorrow.at_noon)
+
+      events = [event1, event2, event3].shuffle
+      calendar = SimpleCalendar::Calendar.new(ViewContext.new, events: events)
+
+      sorted_events = calendar.send(:sorted_events)
+
+      expect(sorted_events[today]).to eq([event1, event2])
+      expect(sorted_events[tomorrow]).to eq([event1, event3])
+    end
+
     it 'handles events without a start time' do
       event = double(start_time: nil)
       calendar = SimpleCalendar::Calendar.new(ViewContext.new, events: [event])


### PR DESCRIPTION
This pull request supports issue https://github.com/excid3/simple_calendar/issues/147.

It adds the ability to specify multi-day events via either the default `end_time` event attribute (or a custom attribute specified by `end_attribute`).  The code simply enumerates the date range between `start_time` and `end_time` which results in the event being present on each day in the calendar. 

👍 to @excid3 for the code succinctness and writing such a clean gem in the first place!  