### PR TITLE
Allow the start_date parameter to be customized

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -46,11 +46,11 @@ module SimpleCalendar
     end
 
     def url_for_next_view
-      view_context.url_for(@params.merge(start_date: date_range.last + 1.day))
+      view_context.url_for(@params.merge(start_date_param => date_range.last + 1.day))
     end
 
     def url_for_previous_view
-      view_context.url_for(@params.merge(start_date: date_range.first - 1.day))
+      view_context.url_for(@params.merge(start_date_param => date_range.first - 1.day))
     end
 
     private
@@ -65,6 +65,10 @@ module SimpleCalendar
 
       def end_attribute
         options.fetch(:end_attribute, :end_time).to_sym
+      end
+
+      def start_date_param
+        options.fetch(:start_date_param, :start_date).to_sym
       end
 
       def sorted_events
@@ -92,7 +96,7 @@ module SimpleCalendar
         if options.has_key?(:start_date)
           options.fetch(:start_date).to_date
         else
-          view_context.params.fetch(:start_date, Date.current).to_date
+          view_context.params.fetch(start_date_param, Date.current).to_date
         end
       end
 

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -3,15 +3,16 @@ require 'action_controller'
 require 'simple_calendar/calendar'
 
 class ViewContext
-  attr_accessor :start_date
+  attr_accessor :start_date, :start_date_param
 
-  def initialize(start_date=nil)
+  def initialize(start_date=nil, options={})
     @start_date = start_date
+    @start_date_param = options.fetch(:start_date_param, :start_date)
   end
 
   def params
     if @start_date.present?
-      ActionController::Parameters.new({start_date: @start_date})
+      ActionController::Parameters.new({start_date_param => @start_date})
     else
       ActionController::Parameters.new
     end
@@ -103,6 +104,12 @@ describe SimpleCalendar::Calendar do
       view_context = ViewContext.new(Date.yesterday)
       calendar = SimpleCalendar::Calendar.new(view_context, start_date: Date.tomorrow)
       expect(calendar.send(:start_date)).to eq(Date.tomorrow)
+    end
+
+    it "takes an option to override the start_date parameter" do
+      view_context = ViewContext.new(Date.yesterday, start_date_param: :date)
+      calendar = SimpleCalendar::Calendar.new(view_context, start_date_param: :date)
+      expect(calendar.send(:start_date)).to eq(Date.yesterday)
     end
   end
 


### PR DESCRIPTION
This lets the `:start_date` parameter to be customized with initializer option.