### PR TITLE
Update README.md for showing the day of the month

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ method.
 <% end %>
 ```
 
+To show the day of the month instead of the date, use `<%= date.day %>`
+
 ### Week Calendar
 
 You can generate a week calendar with the `week_calendar` method.


### PR DESCRIPTION
Several issues (#161, #155, #114) have been opened where it isn't immediately clear how to show the day of the month instead of the date. This PR simply adds a line into the README, under the Month Calendar section, that says how to easily show the day of the month
