### PR TITLE
Allow the use of html in locales file

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,19 @@ And this will render the
 You can copy one of the existing templates to use for the partial for
 your new calendar.
 
+## Use HTML for previous and next links
+
+You can use something like font-awesome to make your next and previous links have a little more flair.
+
+Use your internationalization files to put in the html you want to use.
+In a rails project: config/locales/en.yml
+```
+en:
+  simple_calendar:
+    previous_html: <i class="fas fa-chevron-circle-left"></i>
+    next_html: <i class="fas fa-chevron-circle-right"></i>
+```
+
 ## View Specs and Tests
 
 If you're running view specs against views with calendars, you may run into route generation errors like the following:
@@ -365,19 +378,6 @@ If so, you can stub out the appropriate method like so (rspec 3 and up):
 
 ```
 expect_any_instance_of(SimpleCalendar::Calendar).to receive(:link_to).at_least(:once).and_return("")
-```
-
-## Use HTML for previous and next links
-
-You can use something like font-awesome to make your next and previous links have a little more flair.
-
-Use your internationalization files to put in the html you want to use.
-In a rails project: config/locales/en.yml
-```
-en:
-  simple_calendar:
-    previous_html: <i class="fas fa-chevron-circle-left"></i>
-    next_html: <i class="fas fa-chevron-circle-right"></i>
 ```
 
 With modifications as appropriate.

--- a/README.md
+++ b/README.md
@@ -367,6 +367,19 @@ If so, you can stub out the appropriate method like so (rspec 3 and up):
 expect_any_instance_of(SimpleCalendar::Calendar).to receive(:link_to).at_least(:once).and_return("")
 ```
 
+## Use HTML for previous and next links
+
+You can use something like font-awesome to make your next and previous links have a little more flair.
+
+Use your internationalization files to put in the html you want to use.
+In a rails project: config/locales/en.yml
+```
+en:
+  simple_calendar:
+    previous_html: <i class="fas fa-chevron-circle-left"></i>
+    next_html: <i class="fas fa-chevron-circle-right"></i>
+```
+
 With modifications as appropriate.
 
 ## TODO

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,8 +1,8 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <%= link_to t('simple_calendar.previous_html', default: 'Previous'), calendar.url_for_previous_view %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    <%= link_to t('simple_calendar.next_html', default: 'Next'), calendar.url_for_next_view %>
   </div>
 
   <table class="table table-striped">

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,8 +1,8 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <%= link_to t('simple_calendar.previous_html', default: 'Previous'), calendar.url_for_previous_view %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    <%= link_to t('simple_calendar.next_html', default: 'Next'), calendar.url_for_next_view %>
   </div>
 
   <table class="table table-striped">

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,12 +1,12 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <%= link_to t('simple_calendar.previous_html', default: 'Previous'), calendar.url_for_previous_view %>
     <% if calendar.number_of_weeks == 1 %>
       <span class="calendar-title">Week <%= calendar.week_number %></span>
     <%else%>
         <span class="calendar-title">Week <%= calendar.week_number %> - <%= calendar.end_week %></span>
     <%end%>
-        <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+        <%= link_to t('simple_calendar.next_html', default: 'Next'), calendar.url_for_next_view %>
   </div>
 
   <table class="table table-striped">


### PR DESCRIPTION
Allow the use of html in the en.locales file for simple_calendar.previous and simple_calendar.next.  This allows us to use font awesome tags for the previous and next links