### PR TITLE
Allow to use `#date_range` public

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -65,6 +65,10 @@ module SimpleCalendar
       view_context.url_for(@params.merge(start_date_param => date_range.first - 1.day))
     end
 
+    def date_range
+      (start_date..(start_date + additional_days.days)).to_a
+    end
+
     private
 
       def partial_name
@@ -114,10 +118,6 @@ module SimpleCalendar
 
       def end_date
         date_range.last
-      end
-
-      def date_range
-        (start_date..(start_date + additional_days.days)).to_a
       end
 
       def additional_days

--- a/lib/simple_calendar/month_calendar.rb
+++ b/lib/simple_calendar/month_calendar.rb
@@ -1,10 +1,8 @@
 module SimpleCalendar
   class MonthCalendar < SimpleCalendar::Calendar
-    private
-
-      def date_range
-        (start_date.beginning_of_month.beginning_of_week..start_date.end_of_month.end_of_week).to_a
-      end
+    def date_range
+      (start_date.beginning_of_month.beginning_of_week..start_date.end_of_month.end_of_week).to_a
+    end
   end
 end
 

--- a/lib/simple_calendar/week_calendar.rb
+++ b/lib/simple_calendar/week_calendar.rb
@@ -13,13 +13,11 @@ module SimpleCalendar
       week_number + number_of_weeks - 1
     end
 
-    private
+    def date_range
+      starting = start_date.beginning_of_week
+      ending = (starting + (number_of_weeks - 1).weeks).end_of_week
 
-      def date_range
-        starting = start_date.beginning_of_week
-        ending = (starting + (number_of_weeks - 1).weeks).end_of_week
-
-        (starting..ending).to_a
-      end
+      (starting..ending).to_a
+    end
   end
 end

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -101,13 +101,13 @@ describe SimpleCalendar::Calendar do
   describe 'current week class' do
     it 'should have the current week' do
       calendar = SimpleCalendar::Calendar.new(ViewContext.new)
-      week = calendar.send(:date_range).each_slice(7).to_a[0]
+      week = calendar.date_range.each_slice(7).to_a[0]
       expect(calendar.send(:tr_classes_for, week)).to include('current-week')
     end
 
     it 'should not have the current week if it does not contain today' do
       calendar = SimpleCalendar::MonthCalendar.new(ViewContext.new)
-      week = calendar.send(:date_range).each_slice(7).to_a[0]
+      week = calendar.date_range.each_slice(7).to_a[0]
       expect(calendar.send(:tr_classes_for, week)).to_not include('current-week')
     end
   end
@@ -132,7 +132,7 @@ describe SimpleCalendar::Calendar do
   it 'has a range of dates' do
     calendar = SimpleCalendar::Calendar.new(ViewContext.new)
 
-    calendar_date_range = calendar.render[:locals][:date_range]
+    calendar_date_range = calendar.date_range
 
     expect(calendar_date_range).to be_an(Array)
     expect(calendar_date_range).to all(be_an(Date))


### PR DESCRIPTION
When we don't use view_context, but want to use `SimpleCalendar`,
getting troubled that we cannot use `#render` and cannot access
`#date_range`.

We want to use `SimpleCalendar::Calendar` followings,

```ruby
calendar.date_range.each_slice(7) do |week|
  # do something ...
  week.each do |date|
    # do something ...
  end
end
```

This PR allow to access `#date_range` public.