### PR TITLE
Fix week number

### DIFF
--- a/lib/simple_calendar/week_calendar.rb
+++ b/lib/simple_calendar/week_calendar.rb
@@ -1,7 +1,7 @@
 module SimpleCalendar
   class WeekCalendar < SimpleCalendar::Calendar
     def week_number
-      format = (Date.beginning_of_week == :sunday) ? "%U" : "%W"
+      format = (Date.beginning_of_week == :sunday) ? "%U" : "%V"
       start_date.beginning_of_week.strftime(format).to_i
     end
 


### PR DESCRIPTION
Hi there,

When we call 

> calendar.week_number

The wrong number is rendered. This is because the format is "%W", it should be "%V"
Time.now.strftime('%V') will give you the week number according to ISO 8601.

Is it possible to update this or is it intended ? Had to made my own helper for now. 