### PR TITLE
Fixed a small typo in lib/simple_calendar/calendar.rb

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -15,7 +15,7 @@ module SimpleCalendar
       @params = @params.to_unsafe_h if @params.respond_to?(:to_unsafe_h)
       @params = @params.with_indifferent_access.except(*PARAM_KEY_BLACKLIST)
 
-      # Add in any additonal params the user passed in
+      # Add in any additional params the user passed in
       @params.merge!(@options.fetch(:params, {}))
     end
 


### PR DESCRIPTION
Hi.
It's a very small changes, but it's my first PR to gem, so I'm happy to merge it :)

Changed:
  \# Add in any additonal params the user passed in

To:
  \# Add in any additional params the user passed in
                               