### PR TITLE
[BUGFIX] Format prev/next link date in ISO8601 format

### DIFF
--- a/lib/simple_calendar/calendar.rb
+++ b/lib/simple_calendar/calendar.rb
@@ -58,11 +58,11 @@ module SimpleCalendar
     end
 
     def url_for_next_view
-      view_context.url_for(@params.merge(start_date_param => date_range.last + 1.day))
+      view_context.url_for(@params.merge(start_date_param => (date_range.last + 1.day).iso8601))
     end
 
     def url_for_previous_view
-      view_context.url_for(@params.merge(start_date_param => date_range.first - 1.day))
+      view_context.url_for(@params.merge(start_date_param => (date_range.first - 1.day).iso8601))
     end
 
     def date_range


### PR DESCRIPTION
I ran into a problem while trying to setup simple_calendar in our Rails app.  The issue is that we have the default date format set to `mm/dd/yyyy` (`Date::DATE_FORMATS[:default] = '%m/%d/%Y'`).

This non-standard default date format breaks previous/next calendar links (bad date parsing or error).  This happens because date parsing on server from links assumes `iso8601` format (`yyyy-mm-dd`). 

The `.iso8601` call is standard in ruby date/datetime so should work regardless of using Rails or not.
