### PR TITLE
Fix Rails deprecation warnings

### DIFF
--- a/lib/simple_calendar/railtie.rb
+++ b/lib/simple_calendar/railtie.rb
@@ -1,7 +1,9 @@
 module SimpleCalendar
   class Engine < Rails::Engine
     initializer "simple_calendar.view_helpers" do
-      ActionView::Base.send :include, ViewHelpers
+      ActiveSupport.on_load(:action_view) do
+        include ViewHelpers
+      end
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/rails/rails/issues/36546

It updates the autoloading to remove the deprecation warnings, like described in https://guides.rubyonrails.org/engines.html#load-and-configuration-hooks