### PR TITLE
Replace span element with semantic 'Time' element

### DIFF
--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,7 +1,7 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
     <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
-    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
     <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
   </div>
 


### PR DESCRIPTION
## Improve Accessibility

In an effort to maintain good semantic HTML for accessibility, we replaced the `<span>` element with the new `<time>` element in the `_month_calendar.html.erb` partial using a dynamic `datetime` attribute. 

**Reference**: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time

#### Co-conspirators: @kingrowen, @galtdea, @cjilbert504


