### PR TITLE
Simplify entrypoint

### DIFF
--- a/lib/simple_calendar.rb
+++ b/lib/simple_calendar.rb
@@ -1,13 +1,8 @@
-require "simple_calendar/engine"
-require "simple_calendar/calendar"
-require "simple_calendar/month_calendar"
-require "simple_calendar/week_calendar"
-require "simple_calendar/version"
-require "simple_calendar/view_helpers"
-
 module SimpleCalendar
-  autoload :Calendar, "simple_calendar/calendar"
-  autoload :MonthCalendar, "simple_calendar/month_calendar"
-  autoload :WeekCalendar, "simple_calendar/week_calendar"
-  autoload :ViewHelpers, "simple_calendar/view_helpers"
+  require_relative "simple_calendar/engine"
+  require_relative "simple_calendar/calendar"
+  require_relative "simple_calendar/month_calendar"
+  require_relative "simple_calendar/week_calendar"
+  require_relative "simple_calendar/version"
+  require_relative "simple_calendar/view_helpers"
 end


### PR DESCRIPTION
Hey! :)

The `autoload` calls in this file are unnecessary, because the `require` calls above already define those constants.

Since I was on it, I refactored the way I normally write a file like this. Let me explain:

* Since this file is `simple_calendar.rb`, I find ordered that it owns the _creation_ of the `SimpleCalendar` module. Then, descendants _reopen_. They can also use constant paths like `SimpleCalendar::ViewHelpers` in the definition of child classes and modules if they so wish, because they can rely on the parent module being already defined upwards. (This is only a consequence, not the motivation.)
* For the same price, we can avoid `$LOAD_PATH` lookups by using `require_relative`.

However, these points are kind of personal style, if you prefer something else please just tell me :).