### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/simple_calendar.gemspec
+++ b/simple_calendar.gemspec
@@ -11,6 +11,10 @@ Gem::Specification.new do |s|
   s.description = "A simple Rails calendar"
   s.license = "MIT"
 
+  s.metadata = {
+    'changelog_uri' => https://github.com/excid3/simple_calendar/blob/main/CHANGELOG.md"
+  }
+
   s.rubyforge_project = "simple_calendar"
 
   s.files = `git ls-files`.split("\n")

--- a/simple_calendar.gemspec
+++ b/simple_calendar.gemspec
@@ -1,24 +1,25 @@
 $:.push File.expand_path("../lib", __FILE__)
 require "simple_calendar/version"
 
-Gem::Specification.new do |s|
-  s.name = "simple_calendar"
-  s.version = SimpleCalendar::VERSION
-  s.authors = ["Chris Oliver"]
-  s.email = ["excid3@gmail.com"]
-  s.homepage = "https://github.com/excid3/simple_calendar"
-  s.summary = "A simple Rails calendar"
-  s.description = "A simple Rails calendar"
-  s.license = "MIT"
+Gem::Specification.new do |spec|
+  spec.name = "simple_calendar"
+  spec.version = SimpleCalendar::VERSION
+  spec.authors = ["Chris Oliver"]
+  spec.email = ["excid3@gmail.com"]
+  spec.homepage = "https://github.com/excid3/simple_calendar"
+  spec.summary = "A simple Rails calendar"
+  spec.description = "A simple Rails calendar"
+  spec.license = "MIT"
 
-  s.metadata = {
-    'changelog_uri' => https://github.com/excid3/simple_calendar/blob/main/CHANGELOG.md"
-  }
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "https://github.com/excid3/simple_calendar/blob/main/CHANGELOG.md"
 
-  s.rubyforge_project = "simple_calendar"
+  spec.rubyforge_project = "simple_calendar"
 
-  s.files = `git ls-files`.split("\n")
-  s.require_paths = ["lib"]
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  end
 
-  s.add_dependency "rails", ">= 6.1"
+  spec.add_dependency "rails", ">= 6.1"
 end

--- a/simple_calendar.gemspec
+++ b/simple_calendar.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/excid3/simple_calendar/blob/main/CHANGELOG.md"
 
-  spec.rubyforge_project = "simple_calendar"
-
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end


### PR DESCRIPTION
Documented here: https://guides.rubygems.org/specification-reference/#metadata 

Useful for running https://github.com/MaximeD/gem_updater